### PR TITLE
Fix closing tag typos

### DIFF
--- a/cc/i18n/po/el/cc_org.po
+++ b/cc/i18n/po/el/cc_org.po
@@ -2433,7 +2433,7 @@ msgid ""
 "In particular, if you are an artist or author who depends upon copyright for"
 " your income, Creative Commons <strong>does not recommend</strong> that you "
 "use this tool."
-msgstr "Ειδικότερα, εάν είστε ένας καλλιτέχνης ή συγγραφέας, που επαφίεστε στα δικαιώματα πνευματικής ιδιοκτησίας για το εισόδημά σας, ο οργανισμός Creative Commons <strong>δεν συνιστά</ strong>τη χρήση αυτού του εργαλείου."
+msgstr "Ειδικότερα, εάν είστε ένας καλλιτέχνης ή συγγραφέας, που επαφίεστε στα δικαιώματα πνευματικής ιδιοκτησίας για το εισόδημά σας, ο οργανισμός Creative Commons <strong>δεν συνιστά</strong>τη χρήση αυτού του εργαλείου."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/zero/confirm.html:34
 msgid ""
@@ -2490,7 +2490,7 @@ msgid ""
 "metadata for marking your work as being available under CC0.  Your work will"
 " not be associated with CC0 or made available under CC0 until you publish it"
 " marked as being so."
-msgstr "Παρακαλώ σημειώστε ότι αυτό <strong> δεν είναι διαδικασία εγγραφής</ strong> και ο οργανισμός Creative Commons δεν αποθηκεύει κάποιο από τα στοιχεία που εισάγετε. Το εργαλείο αυτό σας καθοδηγεί μέσω της διαδικασίας της δημιουργίας κώδικα HTML με ενσωματωμένα μεταδεδομένα για σήμανση του έργου σας αδειοδοτημένου με CC0. Το έργο σας δεν θα συσχετιστεί με την άδεια CC0 ούτε θα διατεθεί με την άδεια CC0 μέχρι να το δημοσιεύσετε σηματοδοτημένο ως διατιθέμενο μ'αυτήν την άδεια."
+msgstr "Παρακαλώ σημειώστε ότι αυτό <strong> δεν είναι διαδικασία εγγραφής</strong> και ο οργανισμός Creative Commons δεν αποθηκεύει κάποιο από τα στοιχεία που εισάγετε. Το εργαλείο αυτό σας καθοδηγεί μέσω της διαδικασίας της δημιουργίας κώδικα HTML με ενσωματωμένα μεταδεδομένα για σήμανση του έργου σας αδειοδοτημένου με CC0. Το έργο σας δεν θα συσχετιστεί με την άδεια CC0 ούτε θα διατεθεί με την άδεια CC0 μέχρι να το δημοσιεύσετε σηματοδοτημένο ως διατιθέμενο μ'αυτήν την άδεια."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/zero/partner.html:26
 #, python-format
@@ -2966,7 +2966,7 @@ msgid ""
 "id=\"indicate_changes_popup\" class=\"helpLink\">indicate if changes were "
 "made</a></span>.  You may do so in any reasonable manner, but not in any way"
 " that suggests the licensor endorses you or your use."
-msgstr "Θα πρέπει να καταχωρίσετε <a href=\"#\" id=\"appropriate_credit_popup\" class=\"helpLink\"> αναφορά στο δημιουργό </a> </ span>, με σύνδεσμο της άδειας, και <span rel = \"cc:cc:requires\" resource= \"http://creativecommons.org/ns#Notice\"> <a href=\"#\" id=\"indicate_changes_popup\" class=\"helpLink\"> με αναφορά αν έχουν γίνει αλλαγές </a> </ span>. Μπορείτε να το κάνετε αυτό με οποιονδήποτε εύλογο τρόπο, αλλά όχι με τρόπο που να υπονοεί ότι ο δημιουργός αποδέχεται το έργο σας ή τη χρήση που εσείς κάνετε."
+msgstr "Θα πρέπει να καταχωρίσετε <a href=\"#\" id=\"appropriate_credit_popup\" class=\"helpLink\"> αναφορά στο δημιουργό </a> </span>, με σύνδεσμο της άδειας, και <span rel = \"cc:cc:requires\" resource= \"http://creativecommons.org/ns#Notice\"> <a href=\"#\" id=\"indicate_changes_popup\" class=\"helpLink\"> με αναφορά αν έχουν γίνει αλλαγές </a> </span>. Μπορείτε να το κάνετε αυτό με οποιονδήποτε εύλογο τρόπο, αλλά όχι με τρόπο που να υπονοεί ότι ο δημιουργός αποδέχεται το έργο σας ή τη χρήση που εσείς κάνετε."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/licenses/standard_deed.html:98
 msgid "Attribute this work:"

--- a/cc/i18n/po/es/cc_org.po
+++ b/cc/i18n/po/es/cc_org.po
@@ -1657,7 +1657,7 @@ msgstr "Metadatos XMP."
 msgid ""
 "CC metadata can be embedded into images and many other file formats!  <a target=\"_blank\" href=\"http://wiki.creativecommons.org/XMP\">See the wiki for more info</a>.\n"
 "            "
-msgstr "¡Los metadatos CC pueden incluirse en imágenes y muchos otros formatos de archivo! <a target=\"_blank\" href=\"http://wiki.creativecommons.org/XMP\"> Ver la wiki para más información </ a>."
+msgstr "¡Los metadatos CC pueden incluirse en imágenes y muchos otros formatos de archivo! <a target=\"_blank\" href=\"http://wiki.creativecommons.org/XMP\"> Ver la wiki para más información </a>."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/interactive_chooser.html:1640
 #, python-format
@@ -2917,13 +2917,13 @@ msgstr "Usted es libre para: "
 msgid ""
 "<strong>Share</strong>  &mdash; copy and redistribute the material in any "
 "medium or format"
-msgstr "<strong>Compartir</ strong> &mdash; copiar y redistribuir el material en cualquier medio o formato"
+msgstr "<strong>Compartir</strong> &mdash; copiar y redistribuir el material en cualquier medio o formato"
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/licenses/standard_deed.html:63
 msgid ""
 "<strong>Adapt</strong>  &mdash; remix, transform, and build upon the "
 "material"
-msgstr "<strong> Adaptar</ strong>  &mdash; remezclar, transformar y crear a partir del material"
+msgstr "<strong> Adaptar</strong>  &mdash; remezclar, transformar y crear a partir del material"
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/licenses/standard_deed.html:69
 msgid "for any purpose, even commercially."
@@ -2981,7 +2981,7 @@ msgid ""
 "If you <a href=\"#\" id=\"some_kinds_of_mods_popup\" "
 "class=\"helpLink\">remix, transform, or build upon</a> the material, you may"
 " not distribute the modified material."
-msgstr "Si usted <a href=\"#\" id=\"some_kinds_of_mods_popup\" class=\"helpLink\">mezcla, transforma o crea nuevo material a partir de esta obra</ a>, usted no podrá distribuir el material modificado."
+msgstr "Si usted <a href=\"#\" id=\"some_kinds_of_mods_popup\" class=\"helpLink\">mezcla, transforma o crea nuevo material a partir de esta obra</a>, usted no podrá distribuir el material modificado."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/licenses/standard_deed.html:147
 msgid ""
@@ -3000,7 +3000,7 @@ msgid ""
 "id=\"technological_measures_popup\" class=\"helpLink\">technological "
 "measures</a> that legally restrict others from doing anything the license "
 "permits."
-msgstr "Usted no puede aplicar términos legales ni <a href=\"#\" id=\"technological_measures_popup\" class=\"helpLink\"> medidas tecnológicas</ a> que restrinjan legalmente a otros hacer cualquier uso permitido por la licencia."
+msgstr "Usted no puede aplicar términos legales ni <a href=\"#\" id=\"technological_measures_popup\" class=\"helpLink\"> medidas tecnológicas</a> que restrinjan legalmente a otros hacer cualquier uso permitido por la licencia."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/licenses/standard_deed.html:164
 msgid "Notices:"

--- a/cc/i18n/po/es_ES/cc_org.po
+++ b/cc/i18n/po/es_ES/cc_org.po
@@ -2986,7 +2986,7 @@ msgid ""
 "If you remix, transform, or build upon the material, you must distribute "
 "your contributions under the <a href=\"#\" id=\"same_license_popup\" "
 "class=\"helpLink\">same license</a> as the original."
-msgstr "Si remezcla, transforma o crea a partir del material, deberá difundir sus contribuciones bajo la <a href=\"#\" id=\"same_license_popup\" class=\"helpLink\"> misma licencia </ a> que el original."
+msgstr "Si remezcla, transforma o crea a partir del material, deberá difundir sus contribuciones bajo la <a href=\"#\" id=\"same_license_popup\" class=\"helpLink\"> misma licencia </a> que el original."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/licenses/standard_deed.html:158
 msgid "No additional restrictions"

--- a/cc/i18n/po/lt/cc_org.po
+++ b/cc/i18n/po/lt/cc_org.po
@@ -1862,7 +1862,7 @@ msgid ""
 " search engines to find similarly licensed works, and for tools to "
 "automatically recognize information about the work (such as who authored "
 "it)."
-msgstr "Pateikiamas HTML kodas, kurį galite nukopijuoti į savo tinklalapį. HTML kodas yra su mašinoms suprantamais <a target=\"_blank\" href=\"http://wiki.creativecommons.org/Metadata\"> metaduomenimis</ a>. Tai leidžia paieškos sistemoms rasti panašiai licencijuotų kūrinių, o įrankiams automatiškai aptikti informaciją apie kūrinį (pavyzdžiui, kas jį sukūrė)."
+msgstr "Pateikiamas HTML kodas, kurį galite nukopijuoti į savo tinklalapį. HTML kodas yra su mašinoms suprantamais <a target=\"_blank\" href=\"http://wiki.creativecommons.org/Metadata\"> metaduomenimis</a>. Tai leidžia paieškos sistemoms rasti panašiai licencijuotų kūrinių, o įrankiams automatiškai aptikti informaciją apie kūrinį (pavyzdžiui, kas jį sukūrė)."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/interactive_chooser.html:1864
 msgid ""

--- a/cc/i18n/po/ms/cc_org.po
+++ b/cc/i18n/po/ms/cc_org.po
@@ -1147,7 +1147,7 @@ msgid ""
 "href=\"http://commons.wikimedia.org/wiki/Main_Page\">Wikimedia Commons</a>, "
 "the multimedia repository of <a href=\"http://wikipedia.org\">Wikipedia</a>,"
 " is a core user of our licenses as well."
-msgstr "Mencari kandungan terbuka adalah fungsi penting yang dibolehkan oleh pendekatan kita. Anda boleh menggunakan <a href=\"http://www.google.com/support/websearch/bin/answer.py?&amp;answer=29508&amp;hl=\"> Google</a> untuk mencari kandungan Creative commons, mencari gambar-gambar di <a href=\"http://www.flickr.com/creativecommons/\"> Flickr </ a>, album di <a href = \"http://www.jamendo.com/en/creativecommons\" > Jamendo </ a>, dan media umum di <a href=\"http://spinxpress.com/\"> spinxpress </ a>. <a href=\"http://commons.wikimedia.org/wiki/Main_Page\">Wikimedia Commons</a>, repositori multimedia <a href=\"http://wikipedia.org\"> Wikipedia </ a> juga adalah salah pengguna utama lesen-lesen kami."
+msgstr "Mencari kandungan terbuka adalah fungsi penting yang dibolehkan oleh pendekatan kita. Anda boleh menggunakan <a href=\"http://www.google.com/support/websearch/bin/answer.py?&amp;answer=29508&amp;hl=\"> Google</a> untuk mencari kandungan Creative commons, mencari gambar-gambar di <a href=\"http://www.flickr.com/creativecommons/\"> Flickr </a>, album di <a href = \"http://www.jamendo.com/en/creativecommons\" > Jamendo </a>, dan media umum di <a href=\"http://spinxpress.com/\"> spinxpress </a>. <a href=\"http://commons.wikimedia.org/wiki/Main_Page\">Wikimedia Commons</a>, repositori multimedia <a href=\"http://wikipedia.org\"> Wikipedia </a> juga adalah salah pengguna utama lesen-lesen kami."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/catalog_pages/licenses-index.html:204
 msgid ""
@@ -1408,7 +1408,7 @@ msgid ""
 "international licenses do not, then you may want to consider\n"
 "<a href=\"http://wiki.creativecommons.org/Frequently_Asked_Questions#Should_I_choose_an_international_license_or_a_ported_license.3F\">which\n"
 "license is better suited for your needs</a>."
-msgstr "Guna pilihan \"Antarabangsa\" sekiranya anda ingin sesuatu lesen dengan menggunakan bahasa \ndan istilah daripada perjanjian-perjanjian antarabangsa. Jika lesen-lesen ini telah \ndialihkan ke bidang kuasa anda dan anda merasakan bahawa bidang kuasa\nakaun lesen pangkalan untuk beberapa aspek undang-undang tempatan yang \nlesen antarabangsanya tidak dialihkan, maka anda mungkin mahu mempertimbangkan \n<a href=\"http://wiki.creativecommons.org/Frequently_Asked_Questions#Should_I_choose_an_international_license_or_a_ported_license.3F\">\nlesen yang lebih sesuai untuk keperluan anda</ a>."
+msgstr "Guna pilihan \"Antarabangsa\" sekiranya anda ingin sesuatu lesen dengan menggunakan bahasa \ndan istilah daripada perjanjian-perjanjian antarabangsa. Jika lesen-lesen ini telah \ndialihkan ke bidang kuasa anda dan anda merasakan bahawa bidang kuasa\nakaun lesen pangkalan untuk beberapa aspek undang-undang tempatan yang \nlesen antarabangsanya tidak dialihkan, maka anda mungkin mahu mempertimbangkan \n<a href=\"http://wiki.creativecommons.org/Frequently_Asked_Questions#Should_I_choose_an_international_license_or_a_ported_license.3F\">\nlesen yang lebih sesuai untuk keperluan anda</a>."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/classic_chooser.html:230
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/partner/index.html:95
@@ -1797,7 +1797,7 @@ msgid ""
 "        The <a href=\"http://freedomdefined.org/Definition\">free culture definition</a> \n"
 "        and <a href=\"http://freedomdefined.org/Permissible_restrictions\">permissible restrictions</a>\n"
 "        pages are wonderful starting points for further learning."
-msgstr "Freedomdefined.org adalah satu sumber maklumat tentang budaya bebas. \n<a href=\"http://freedomdefined.org/Definition\"> Definisi budaya bebas </ a> \ndan <a href=\"http://freedomdefined.org/Permissible_restrictions\"> sekatan dibenarkan </ a> \nadalah laman tarikan titik permulaan untuk pembelajaran lebih lanjut."
+msgstr "Freedomdefined.org adalah satu sumber maklumat tentang budaya bebas. \n<a href=\"http://freedomdefined.org/Definition\"> Definisi budaya bebas </a> \ndan <a href=\"http://freedomdefined.org/Permissible_restrictions\"> sekatan dibenarkan </a> \nadalah laman tarikan titik permulaan untuk pembelajaran lebih lanjut."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/interactive_chooser.html:1824
 msgid ""
@@ -2369,7 +2369,7 @@ msgid ""
 "        <p>Dedicator makes this dedication for the benefit of the public at large and to the detriment of the Dedicator's heirs and successors. Dedicator intends this dedication to be an overt act of relinquishment in perpetuity of all present and future rights under copyright law, whether vested or contingent, in the Work. Dedicator understands that such relinquishment of all rights includes the relinquishment of all rights to enforce (by lawsuit or otherwise) those copyrights in the Work.</p>\n"
 "\n"
 "        <p>Dedicator recognizes that, once placed in the public domain, the Work may be freely reproduced, distributed, transmitted, used, modified, built upon, or otherwise exploited by anyone for any purpose, commercial or non-commercial, and in any way, including by methods that have not yet been invented or conceived.</p>"
-msgstr "<p>Orang atau seseorang yang telah mengaitkan karya dengan dokumen ini (\"yang mempersembahkan\" atau \"Pengesah\") dengan ini sama ada (a) memperakui bahawa, sepanjang pengetahuannya, yang karya ciptaan yang dikenal pasti adalah di dalam domain awam negara di mana karya tersebut disiarkan, atau (b) dengan ini mendedikasikan apa sahaja hak cipta yang mempersembahkan memegang dalam karya ciptaan yang dikenal pasti di bawah (\"Karya\") kepada domain awam. Seseorang pengeluar sijil, lebih-lebih lagi, mendedikasikan apa-apa kepentingan hak cipta dia mungkin ada dalam kerja-kerja yang berkaitan, dan untuk tujuan ini, digambarkan sebagai \"yg mempersembahkan\" di bawah. </ P>"
+msgstr "<p>Orang atau seseorang yang telah mengaitkan karya dengan dokumen ini (\"yang mempersembahkan\" atau \"Pengesah\") dengan ini sama ada (a) memperakui bahawa, sepanjang pengetahuannya, yang karya ciptaan yang dikenal pasti adalah di dalam domain awam negara di mana karya tersebut disiarkan, atau (b) dengan ini mendedikasikan apa sahaja hak cipta yang mempersembahkan memegang dalam karya ciptaan yang dikenal pasti di bawah (\"Karya\") kepada domain awam. Seseorang pengeluar sijil, lebih-lebih lagi, mendedikasikan apa-apa kepentingan hak cipta dia mungkin ada dalam kerja-kerja yang berkaitan, dan untuk tujuan ini, digambarkan sebagai \"yg mempersembahkan\" di bawah. </p>"
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/publicdomain/publicdomain-3.html:65
 msgid ""
@@ -2608,7 +2608,7 @@ msgid ""
 "\t    information</a> on Creative Commons metadata is available if\n"
 "\t  you want to find out more.\n"
 "\t</p>"
-msgstr "<p> \n⇥ Maklumat yang tertanam dalam perisian yang formatnya mudah dibaca. \n⇥ Memudahkan enjin pencariaan mengindeks maklumat tambahan\n⇥ mengenai karya anda dan membenarkan orang tiba ke lesen surat ikatan \n⇥ dari halaman anda untuk melihat maklumat akta mengenai bagaimana untuk\n⇥ atribut karya anda. \n⇥ </p> \n⇥ <p> \n⇥ <a href=\"http://wiki.creativecommons.org/Metadata\">Lagi\n⇥ maklumat </ a> pada metadata Creative Commons disediakan sekiranya \n⇥ anda ingin mengetahui lebih lanjut. \n⇥ </ p>"
+msgstr "<p> \n⇥ Maklumat yang tertanam dalam perisian yang formatnya mudah dibaca. \n⇥ Memudahkan enjin pencariaan mengindeks maklumat tambahan\n⇥ mengenai karya anda dan membenarkan orang tiba ke lesen surat ikatan \n⇥ dari halaman anda untuk melihat maklumat akta mengenai bagaimana untuk\n⇥ atribut karya anda. \n⇥ </p> \n⇥ <p> \n⇥ <a href=\"http://wiki.creativecommons.org/Metadata\">Lagi\n⇥ maklumat </a> pada metadata Creative Commons disediakan sekiranya \n⇥ anda ingin mengetahui lebih lanjut. \n⇥ </p>"
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/includes/more_metadata.html:40
 msgid "Tell us the format of your work:"
@@ -3136,7 +3136,7 @@ msgid ""
 "work is used, such as <a "
 "href=\"http://wiki.creativecommons.org/Frequently_Asked_Questions#When_are_publicity_rights_relevant.3F\""
 " class=\"helpLink\" id=\"publicity_rights\">publicity or privacy</a> rights."
-msgstr "Sama sekali tidak adalah paten atau tanda hak mana-mana orang yang terjejas oleh CC0, tidak pula hak-hak yang orang lain mungkin terdapat dalam karya atau dalam cara karya digunakan, seperti <a href=\"http://wiki.creativecommons.org/Frequently_Asked_Questions#When_are_publicity_rights_relevant.3F\" class=\"helpLink\" id=\"publicity_rights\">publisiti atau hak privasi</ a>."
+msgstr "Sama sekali tidak adalah paten atau tanda hak mana-mana orang yang terjejas oleh CC0, tidak pula hak-hak yang orang lain mungkin terdapat dalam karya atau dalam cara karya digunakan, seperti <a href=\"http://wiki.creativecommons.org/Frequently_Asked_Questions#When_are_publicity_rights_relevant.3F\" class=\"helpLink\" id=\"publicity_rights\">publisiti atau hak privasi</a>."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/licenses/zero_deed.html:87
 msgid ""

--- a/cc/i18n/po/nl/cc_org.po
+++ b/cc/i18n/po/nl/cc_org.po
@@ -2015,7 +2015,7 @@ msgid ""
 "href=\"%(cc0_url)s\">CC0</a>. If you're sharing a work that isn't covered by"
 " copyright or on which the copyright has expired, choose the <a "
 "href=\"%(pd_url)s\">Public Domain Mark</a>."
-msgstr "Als je een zelfgemaakt werk zonder voorwaarden wilt delen, kies dan voor <a href=\"%(cc0_url)s\">CC0</ a>.\nAls je een werk deelt dat niet door het auteursrecht beschermd is of waarvan het auteursrecht is verlopen, kies dan de <a href=\"%(pd_url)s\">Public Domain Mark</ a>."
+msgstr "Als je een zelfgemaakt werk zonder voorwaarden wilt delen, kies dan voor <a href=\"%(cc0_url)s\">CC0</a>.\nAls je een werk deelt dat niet door het auteursrecht beschermd is of waarvan het auteursrecht is verlopen, kies dan de <a href=\"%(pd_url)s\">Public Domain Mark</a>."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/partner/index.html:31
 #, python-format
@@ -2324,7 +2324,7 @@ msgid ""
 "tool</a>. CC recommends using a <a "
 "href=\"http://creativecommons.org/publicdomain\">current tool</a> for "
 "waiving rights or identifying public domain works."
-msgstr "Creative Commons heeft <a href=\"http://creativecommons.org/retiredlicenses\"> dit juridische instrument verwijderd uit haar aanbod </ a>. Gebruik <a href=\"http://creativecommons.org/publicdomain\">deze tool</ a> om afstand te doen van de auteursrechten van een werk of om publieke domein werken te markeren."
+msgstr "Creative Commons heeft <a href=\"http://creativecommons.org/retiredlicenses\"> dit juridische instrument verwijderd uit haar aanbod </a>. Gebruik <a href=\"http://creativecommons.org/publicdomain\">deze tool</a> om afstand te doen van de auteursrechten van een werk of om publieke domein werken te markeren."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/publicdomain/publicdomain-2.html:19
 msgid ""
@@ -2337,7 +2337,7 @@ msgid ""
 "    using <a href=\"/license/zero/\">CC0</a>.  Please note that if you\n"
 "    use the Public Domain Certification to dedicate a work to the\n"
 "    public domain, it may not be valid outside of the United States."
-msgstr "Je hebt gekozen voor de Publieke Domein Certificering. De Publieke\nDomein Verklaring dient alleen gebruikt te worden voor het certificeren\nvan een werk dat in het publieke domein is. Creative Commons raadt\nniet aan om deze certificering aan een werk te wijden dat nog\nbeschermd wordt door het auteursrecht. Overweeg <a href=\"/license/zero/\"> CC0 </ a> te gebruiken\nom je werk aan het publieke domein te wijden.\nHoud er rekening mee dat de Publieke Domein Verklaring mogelijk niet geldig is buiten de Verenigde Staten."
+msgstr "Je hebt gekozen voor de Publieke Domein Certificering. De Publieke\nDomein Verklaring dient alleen gebruikt te worden voor het certificeren\nvan een werk dat in het publieke domein is. Creative Commons raadt\nniet aan om deze certificering aan een werk te wijden dat nog\nbeschermd wordt door het auteursrecht. Overweeg <a href=\"/license/zero/\"> CC0 </a> te gebruiken\nom je werk aan het publieke domein te wijden.\nHoud er rekening mee dat de Publieke Domein Verklaring mogelijk niet geldig is buiten de Verenigde Staten."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/publicdomain/publicdomain-2.html:31
 msgid ""

--- a/cc/i18n/po/pl/cc_org.po
+++ b/cc/i18n/po/pl/cc_org.po
@@ -1895,7 +1895,7 @@ msgid ""
 "target=\"_blank\" href=\"http://wiki.creativecommons.org/RDFa\">RDFa</a> "
 "metadata, which allows search engines to accurately determine which license "
 "your work is under, and how you want to be attributed."
-msgstr "Kod HTML z tego panelu można wkleić na własną stronę, aby powiadomić innych na jakiej licencji jest udostępniany utwór, i kto jest jego autorem. HTML łączy informacje z paneli \"Zawartość licencji\" oraz \"Pomóż innym uznać Twoje autorstwo\". HTML zawiera metadane w standardzie <a target=\"_blank\" href=\"http://wiki.creativecommons.org/RDFa\"> RDFa</ a> , co pozwala wyszukiwarkom dokładnie określić, na jakiej licencji jest udostępniony utwór i w jaki sposób chcesz by było uznawane twoje autorstwo. "
+msgstr "Kod HTML z tego panelu można wkleić na własną stronę, aby powiadomić innych na jakiej licencji jest udostępniany utwór, i kto jest jego autorem. HTML łączy informacje z paneli \"Zawartość licencji\" oraz \"Pomóż innym uznać Twoje autorstwo\". HTML zawiera metadane w standardzie <a target=\"_blank\" href=\"http://wiki.creativecommons.org/RDFa\"> RDFa</a> , co pozwala wyszukiwarkom dokładnie określić, na jakiej licencji jest udostępniony utwór i w jaki sposób chcesz by było uznawane twoje autorstwo. "
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/chooser_pages/interactive_chooser.html:1880
 msgid ""

--- a/cc/i18n/po/tr/cc_org.po
+++ b/cc/i18n/po/tr/cc_org.po
@@ -3123,7 +3123,7 @@ msgid ""
 "work to the public domain by waiving all of his or her rights to the work "
 "worldwide under copyright law, including all related and neighboring rights,"
 " to the extent allowed by law."
-msgstr "Bu özet ile eserini ilişkilendiren kişi, eserini Kamu Malı olarak <b>adar</ b>, tüm ilgili ve komşu haklar dahil olmak üzere, telif haklarından kanunların izin verdiği sınırlarda dünya çapında feragat eder."
+msgstr "Bu özet ile eserini ilişkilendiren kişi, eserini Kamu Malı olarak <b>adar</b>, tüm ilgili ve komşu haklar dahil olmak üzere, telif haklarından kanunların izin verdiği sınırlarda dünya çapında feragat eder."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/licenses/zero_deed.html:36
 msgid ""


### PR DESCRIPTION
Fix a number of typos with closing tags, e.g. `</ strong>` → `</strong>`.
