### PR TITLE
Fixes non-existing legalcode issues.

### DIFF
--- a/cc/i18n/po/fr/cc_org.po
+++ b/cc/i18n/po/fr/cc_org.po
@@ -3336,7 +3336,7 @@ msgstr "C'est un résumé (et non pas un substitut) de la licence, qui est dispo
 msgid ""
 "This is a human-readable summary of (and not a substitute for) the <a "
 "href=\"legalcode\" class=\"fulltext\">license</a>."
-msgstr "C'est un résumé (et non pas un substitut) de la <a href=\"legalcode.fr\" class=\"fulltext\">licence</a>."
+msgstr "C'est un résumé (et non pas un substitut) de la <a href=\"legalcode\" class=\"fulltext\">licence</a>."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/macros_templates/deed.html:130
 #, python-format

--- a/cc/i18n/po/hr/cc_org.po
+++ b/cc/i18n/po/hr/cc_org.po
@@ -3322,7 +3322,7 @@ msgstr "Ovo je svima razumljiv sažetak, a ne zamjena za licencu koja je dostupn
 msgid ""
 "This is a human-readable summary of (and not a substitute for) the <a "
 "href=\"legalcode\" class=\"fulltext\">license</a>."
-msgstr "Ovo je svima razumljiv sažetak (a ne zamjena za)  <a href=\"legalcode.hr\" class=\"fulltext\">licencu</a>."
+msgstr "Ovo je svima razumljiv sažetak (a ne zamjena za)  <a href=\"legalcode\" class=\"fulltext\">licencu</a>."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/macros_templates/deed.html:130
 #, python-format

--- a/cc/i18n/po/no/cc_org.po
+++ b/cc/i18n/po/no/cc_org.po
@@ -3319,7 +3319,7 @@ msgstr "Dette er et menneske-lesbart sammendrag av (men ingen erstatning for) de
 msgid ""
 "This is a human-readable summary of (and not a substitute for) the <a "
 "href=\"legalcode\" class=\"fulltext\">license</a>."
-msgstr "Dette er et menneske-lesbart sammendrag av (men ingen erstatning for) den <a href=\"legalcode.no\" class=\"fulltext\">juridiske lisensteksten</a>."
+msgstr "Dette er et menneske-lesbart sammendrag av (men ingen erstatning for) den <a href=\"legalcode\" class=\"fulltext\">juridiske lisensteksten</a>."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/macros_templates/deed.html:130
 #, python-format

--- a/cc/i18n/po/pl/cc_org.po
+++ b/cc/i18n/po/pl/cc_org.po
@@ -3331,7 +3331,7 @@ msgstr "Poniższy tekst jest jedynie przystępnym podsumowaniem licencji (które
 msgid ""
 "This is a human-readable summary of (and not a substitute for) the <a "
 "href=\"legalcode\" class=\"fulltext\">license</a>."
-msgstr "Poniższy tekst jest jedynie przystępnym podsumowaniem <a href=\"legalcode.pl\" class=\"fulltext\">licencji</a> (której nie zastępuje)."
+msgstr "Poniższy tekst jest jedynie przystępnym podsumowaniem <a href=\"legalcode\" class=\"fulltext\">licencji</a> (której nie zastępuje)."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/macros_templates/deed.html:130
 #, python-format

--- a/cc/i18n/po/ro/cc_org.po
+++ b/cc/i18n/po/ro/cc_org.po
@@ -3327,7 +3327,7 @@ msgstr "Acesta este un rezumat pe înțelesul tuturor (și nu un substitut) al l
 msgid ""
 "This is a human-readable summary of (and not a substitute for) the <a "
 "href=\"legalcode\" class=\"fulltext\">license</a>."
-msgstr "Acesta e un rezumat pe înțelesul tuturor (și nu un substitut) al <a href=\"legalcode.ro\" class=\"fulltext\">licenței</a>."
+msgstr "Acesta e un rezumat pe înțelesul tuturor (și nu un substitut) al <a href=\"legalcode\" class=\"fulltext\">licenței</a>."
 
 #: checkouts/creativecommons.org/python_env/src/cc.engine/cc/engine/templates/macros_templates/deed.html:130
 #, python-format


### PR DESCRIPTION
Fixes 3.0 deed issue referring to non-existing legalcodes.

Since 2015 there have been about a dozen tickets about not being able to reach certain legalcodes of the 3.0 license suite. See an overview here: https://github.com/creativecommons/creativecommons.org/issues?q=is%3Aissue+is%3Aopen+label%3Alegalcode

These include the French, Norwegian, Hungarian, Polish and Romanian legalcodes of the 3.0 license suite. It also included the Dutch language. I did provide and communicated this fix (see https://github.com/creativecommons/creativecommons.org/issues/54 )

All these languages have an active community that ported the 3.0 licenses AND translated the 4.0 licenses, including updating the Deed pages.

This pull request fixes this immediate issue. I don't know if we can update the transifex string bi-directionally. If not an admin can fix these strings.

However be aware that this does create a new issue. When you go to the 4.0 deed pages of these languages and click on the full text license link you will get the english version and not the same language version of the deed.